### PR TITLE
fix: travis deployment failing because hostname missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 addons:
   ssh_known_hosts:
     - 172.104.242.14
+    - stephankennedy.de
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_5f13cb150a72_key -iv $encrypted_5f13cb150a72_iv -in scripts/gatsby-deploy.enc -out scripts/gatsby-deploy -d
@@ -16,6 +17,7 @@ before_install:
   - chmod 600 ~/.ssh/gatsby-deploy
   - ssh-add ~/.ssh/gatsby-deploy
   - echo -e "Host 172.104.242.14\n\tStrictHostKeyChecking=no\n" >> ~/.ssh/config
+  - echo -e "Host stephankennedy.de\n\tStrictHostKeyChecking=no\n" >> ~/.ssh/config
 
 deploy:
   - provider: script


### PR DESCRIPTION
(hostname is used im deploy.sh, rather than ip address)